### PR TITLE
Multi-watcher with round robin orchestrator

### DIFF
--- a/hub/listener.go
+++ b/hub/listener.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"net"
+
+	"github.com/itzmeanjan/pub0sub/ops"
 )
 
 func (h *Hub) listen(ctx context.Context, addr string, done chan bool) {
@@ -48,7 +50,7 @@ func (h *Hub) listen(ctx context.Context, addr string, done chan bool) {
 			watcher := h.watchers[nextWatcher]
 
 			watcher.lock.Lock()
-			watcher.ongoingRead[conn] = &readState{buf: buf}
+			watcher.ongoingRead[conn] = &readState{buf: buf, opcode: ops.UNSUPPORTED}
 			watcher.lock.Unlock()
 
 			if err := watcher.eventLoop.Read(ctx, conn, buf); err != nil {

--- a/hub/listener.go
+++ b/hub/listener.go
@@ -47,7 +47,10 @@ func (h *Hub) listen(ctx context.Context, addr string, done chan bool) {
 
 			buf := make([]byte, 5)
 			nextWatcher = (nextWatcher + 1) % h.watcherCount
+
+			h.watchersLock.RLock()
 			watcher := h.watchers[nextWatcher]
+			h.watchersLock.RUnlock()
 
 			watcher.lock.Lock()
 			watcher.ongoingRead[conn] = &readState{buf: buf, opcode: ops.UNSUPPORTED}

--- a/hub/reader.go
+++ b/hub/reader.go
@@ -108,7 +108,7 @@ func (h *Hub) handleNewSubscription(ctx context.Context, id uint, conn net.Conn,
 	// when need can run eviction routine targeting
 	// this subscriber ( unique id )
 	h.connectedSubscribersLock.Lock()
-	h.connectedSubscribers[conn] = subId
+	h.connectedSubscribers[conn] = &subInfo{id: subId, watcherId: id}
 	h.connectedSubscribersLock.Unlock()
 
 	// writing message into stream

--- a/hub/reader.go
+++ b/hub/reader.go
@@ -20,7 +20,11 @@ func (h *Hub) handleRead(ctx context.Context, id uint, result gaio.OpResult) err
 	}
 
 	data := result.Buffer[:result.Size]
+
+	h.watchersLock.RLock()
 	watcher := h.watchers[id]
+	h.watchersLock.RUnlock()
+
 	watcher.lock.RLock()
 	defer watcher.lock.RUnlock()
 
@@ -91,6 +95,8 @@ func (h *Hub) handleMessagePublish(ctx context.Context, id uint, conn net.Conn, 
 		return err
 	}
 
+	h.watchersLock.RLock()
+	defer h.watchersLock.RUnlock()
 	return h.watchers[id].eventLoop.Write(ctx, conn, oStream.Bytes())
 }
 
@@ -122,6 +128,8 @@ func (h *Hub) handleNewSubscription(ctx context.Context, id uint, conn net.Conn,
 		return err
 	}
 
+	h.watchersLock.RLock()
+	defer h.watchersLock.RUnlock()
 	return h.watchers[id].eventLoop.Write(ctx, conn, oStream.Bytes())
 }
 
@@ -146,6 +154,8 @@ func (h *Hub) handleUpdateSubscription(ctx context.Context, id uint, conn net.Co
 		return err
 	}
 
+	h.watchersLock.RLock()
+	defer h.watchersLock.RUnlock()
 	return h.watchers[id].eventLoop.Write(ctx, conn, oStream.Bytes())
 }
 
@@ -170,5 +180,7 @@ func (h *Hub) handleUnsubscription(ctx context.Context, id uint, conn net.Conn, 
 		return err
 	}
 
+	h.watchersLock.RLock()
+	defer h.watchersLock.RUnlock()
 	return h.watchers[id].eventLoop.Write(ctx, conn, oStream.Bytes())
 }

--- a/hub/watcher.go
+++ b/hub/watcher.go
@@ -12,7 +12,9 @@ func (h *Hub) watch(ctx context.Context, id uint, done chan struct{}) {
 	// notifying that watcher started
 	done <- struct{}{}
 
+	h.watchersLock.RLock()
 	watcher := h.watchers[id]
+	h.watchersLock.RUnlock()
 	defer func() {
 		if err := watcher.eventLoop.Close(); err != nil {
 			log.Printf("[pub0sub] Error : %s\n", err.Error())

--- a/hub/watcher.go
+++ b/hub/watcher.go
@@ -43,8 +43,8 @@ func (h *Hub) watch(ctx context.Context, id uint, done chan struct{}) {
 						}
 
 						h.connectedSubscribersLock.Lock()
-						if id, ok := h.connectedSubscribers[res.Conn]; ok {
-							h.evict <- id
+						if subInfo, ok := h.connectedSubscribers[res.Conn]; ok {
+							h.evict <- subInfo.id
 							delete(h.connectedSubscribers, res.Conn)
 						}
 						h.connectedSubscribersLock.Unlock()
@@ -68,8 +68,8 @@ func (h *Hub) watch(ctx context.Context, id uint, done chan struct{}) {
 						}
 
 						h.connectedSubscribersLock.Lock()
-						if id, ok := h.connectedSubscribers[res.Conn]; ok {
-							h.evict <- id
+						if subInfo, ok := h.connectedSubscribers[res.Conn]; ok {
+							h.evict <- subInfo.id
 							delete(h.connectedSubscribers, res.Conn)
 						}
 						h.connectedSubscribersLock.Unlock()

--- a/hub/writer.go
+++ b/hub/writer.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 
+	"github.com/itzmeanjan/pub0sub/ops"
 	"github.com/xtaci/gaio"
 )
 
@@ -15,9 +16,11 @@ func (h *Hub) handleWrite(ctx context.Context, id uint, result gaio.OpResult) er
 	watcher.lock.RLock()
 	defer watcher.lock.RUnlock()
 
-	if enqueued, ok := watcher.ongoingRead[result.Conn]; ok && enqueued.envelopeRead {
-		enqueued.envelopeRead = false
-		return watcher.eventLoop.Read(ctx, result.Conn, enqueued.buf)
+	if ongoing, ok := watcher.ongoingRead[result.Conn]; ok && ongoing.envelopeRead {
+		ongoing.envelopeRead = false
+		ongoing.opcode = ops.UNSUPPORTED
+
+		return watcher.eventLoop.Read(ctx, result.Conn, ongoing.buf)
 	}
 
 	return nil

--- a/orderliness_test.go
+++ b/orderliness_test.go
@@ -33,8 +33,8 @@ func TestDeliveryOrderliness(t *testing.T) {
 	capacity := uint64(256)
 	topic_1 := "topic_1"
 	topics := []string{topic_1}
-	end := uint64(1_000_000)
-	delay := time.Duration(100) * time.Millisecond
+	end := uint64(100_000)
+	delay := 100 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 	h, err := hub.New(ctx, addr, capacity)

--- a/orderliness_test.go
+++ b/orderliness_test.go
@@ -33,7 +33,7 @@ func TestDeliveryOrderliness(t *testing.T) {
 	capacity := uint64(256)
 	topic_1 := "topic_1"
 	topics := []string{topic_1}
-	end := uint64(100_000)
+	end := uint64(10_000)
 	delay := 100 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## What's new ?

Only one watcher go-routine was used previously running single kernel event loop, to which all accepted sockets were delegated to for their life-time. Now I'm experimenting with multiple watcher go-routines so that each can run its own kernel event loop, managing only a subset of all active sockets. 

Accepted connection orchestration is currently done using fairly simple round robin technique. After collecting statistics of this version, I'll consider bringing in feedback loop in picture so that new connection listener go-routine can learn which watcher is doing how much work & make better, informed decision regarding where to delegate newly accepted connection to.

✌️